### PR TITLE
Rename type to kind

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Finally you can parse the json by `PbJsonParser`.
 ```ruby
 [6] pry(main)> PbJsonParser.parse(json: File.read('./protos/resources.proto.json'), filename: 'resources.proto').map(&:to_h)
 => [
- {:name=>"User", :fields=>[{:name=>"id", :type=>"int32"}], :assocs=>[{:name=>"profile", :type=>"has_one", :class_name=>"Profile"}]},
+ {:name=>"User", :fields=>[{:name=>"id", :type=>"int32"}], :assocs=>[{:name=>"profile", :kind=>"has_one", :class_name=>"Profile"}]},
  {:name=>"Profile", :fields=>[{:name=>"id", :type=>"int32"}, {:name=>"birthday", :type=>".google.protobuf.Timestamp"}], :assocs=>[]}
 ]
 ```

--- a/lib/pb_json_parser/ast/association.rb
+++ b/lib/pb_json_parser/ast/association.rb
@@ -1,19 +1,19 @@
 module PbJsonParser
   module AST
     class Association
-      Type = {
+      Kind = {
         has_one:  "has_one".freeze,
         has_many: "has_many".freeze,
       }.freeze
 
-      attr_reader :name, :type, :class_name
+      attr_reader :name, :kind, :class_name
 
       # @param [String] name
-      # @param [String] type
+      # @param [String] kind
       # @param [String] class_name
-      def initialize(name:, type:, class_name:)
+      def initialize(name:, kind:, class_name:)
         @name       = name
-        @type       = type
+        @kind       = kind
         @class_name = class_name
         validate!
       end
@@ -21,7 +21,7 @@ module PbJsonParser
       def to_h
         {
           name:       @name,
-          type:       @type,
+          kind:       @kind,
           class_name: @class_name,
         }
       end
@@ -29,8 +29,8 @@ module PbJsonParser
     private
 
       def validate!
-        if !Type.values.include?(@type)
-          raise "Invalid type: #{@type}"
+        if !Kind.values.include?(@kind)
+          raise "Invalid kind: #{@kind}"
         end
       end
     end

--- a/lib/pb_json_parser/parser.rb
+++ b/lib/pb_json_parser/parser.rb
@@ -58,15 +58,15 @@ module PbJsonParser
     def parse_assoc(field)
       case field["label"]
       when 3  # label: LABEL_REPEATED
-        type = AST::Association::Type[:has_many]
+        kind = AST::Association::Kind[:has_many]
       else
-        type = AST::Association::Type[:has_one]
+        kind = AST::Association::Kind[:has_one]
       end
       class_name = field_message_type(field)
 
       assoc = AST::Association.new(
         name:       field["name"],
-        type:       type,
+        kind:       kind,
         class_name: class_name,
       )
     end

--- a/spec/pb_json_parser_spec.rb
+++ b/spec/pb_json_parser_spec.rb
@@ -21,7 +21,7 @@ describe PbJsonParser do
           assocs: [
             {
               name:       "profile",
-              type:       "has_one",
+              kind:       "has_one",
               class_name: "Profile"
             }
           ]
@@ -40,21 +40,21 @@ describe PbJsonParser do
         {
           name: "User",
           fields: [
-            { name: "id",     type: "int64" },
-            { name: "number", type: "int32" },
-            { name: "admin",  type: "bool" },
-            { name: "name",   type: "string" },
+            { name: "id",       type: "int64" },
+            { name: "number",   type: "int32" },
+            { name: "admin",    type: "bool" },
+            { name: "name",     type: "string" },
             { name: "score",    type: "float" },
             { name: "priority", type: "double" },
             { name: "size",     type: "uint32" },
             { name: "length",   type: "uint64" },
             { name: "record",   type: "bytes" },
-            { name: "flag",   type: ".south37.users_prototype.Flag" },
+            { name: "flag",     type: ".south37.users_prototype.Flag" },
           ],
           assocs: [
             {
               name:       "profile",
-              type:       "has_one",
+              kind:       "has_one",
               class_name: "Profile"
             }
           ]


### PR DESCRIPTION
## WHY
`type` field also exists in `AST::Field`, so `type field` in `AST::Association` is conusing.

## WHAT
Renamed to `kind`