### PR TITLE
Support field_types arguments

### DIFF
--- a/lib/pb_json_parser.rb
+++ b/lib/pb_json_parser.rb
@@ -8,10 +8,11 @@ module PbJsonParser
     # @param [String] json
     # @param [String] filename
     # @return [<AST::Message>]
-    def parse(json:, filename:, skip_fields: [])
+    def parse(json:, filename:, skip_fields: [], field_types: [])
       parser = Parser.new(json: json, filename: filename)
       parser.configure do |c|
         c.skip_fields = skip_fields
+        c.field_types = field_types
       end
       parser.parse
     end

--- a/lib/pb_json_parser/config.rb
+++ b/lib/pb_json_parser/config.rb
@@ -1,9 +1,10 @@
 module PbJsonParser
   class Config
-    attr_reader :skip_fields
+    attr_reader :skip_fields, :field_types
 
     def initialize
       @skip_fields = []
+      @field_types = []
     end
 
     # @param [<String>] fields
@@ -12,6 +13,14 @@ module PbJsonParser
         raise "invalid skip_fields: #{fields}"
       end
       @skip_fields = fields
+    end
+
+    # @param [<String>] types
+    def field_types=(types)
+      if !types.is_a?(Array)
+        raise "invalid field_types: #{types}"
+      end
+      @field_types = types
     end
   end
 end

--- a/lib/pb_json_parser/parser.rb
+++ b/lib/pb_json_parser/parser.rb
@@ -15,6 +15,7 @@ module PbJsonParser
     def parse
       r = []
       @data["message_type"].each do |m_type|
+        next if m_type["name"].in?(@config.field_types)
         m = parse_message(m_type)
         r.push m
       end
@@ -74,7 +75,9 @@ module PbJsonParser
     # @param [{ string => Any }] field
     # @return [bool]
     def is_assoc?(field)
-      field_package(field) == @package
+      return false if field_package(field) != @package
+      return false if field_message_type(field).in?(@config.field_types)
+      true
     end
 
     # @param [Hash] field


### PR DESCRIPTION
## WHY
Sometimes we want to treat message type as field type.

## WHAT
Add `field_types` parameter.
By using this, we can treat a message type as field type.